### PR TITLE
fix: remove legacy payment method label field #18

### DIFF
--- a/give-iats.php
+++ b/give-iats.php
@@ -116,6 +116,8 @@ final class Give_iATS_Gateway {
 			require_once GIVE_IATS_PLUGIN_DIR . '/includes/admin/admin-actions.php';
 		}
 
+		require_once GIVE_IATS_PLUGIN_DIR . '/includes/admin/upgrades/upgrade-functions.php';
+
 		// iATS payment gateways core.
 		require_once GIVE_IATS_PLUGIN_DIR . '/includes/lib/iATSPayments/iATS.php';
 

--- a/includes/admin/class-give-iats-gateways-settings.php
+++ b/includes/admin/class-give-iats-gateways-settings.php
@@ -71,7 +71,7 @@ class Give_iATS_Gateway_Settings {
 	public function add_gateways( $gateways ) {
 		$gateways[ $this->section_id ] = array(
 			'admin_label'    => $this->section_label,
-			'checkout_label' => give_iats_get_payment_method_label(),
+			'checkout_label' => __( 'Credit Card', 'give-iats' ),
 		);
 
 		return $gateways;

--- a/includes/admin/class-give-iats-gateways-settings.php
+++ b/includes/admin/class-give-iats-gateways-settings.php
@@ -109,13 +109,6 @@ class Give_iATS_Gateway_Settings {
 				'type' => 'title',
 			),
 			array(
-				'name'    => __( 'Payment Method Label', 'give-iats' ),
-				'id'      => 'iats_payment_method_label',
-				'type'    => 'text',
-				'default' => __( 'Credit Card', 'give-iats' ),
-				'desc'    => __( 'Payment method label will appear on the frontend.', 'give-iats' ),
-			),
-			array(
 				'name' => __( 'Live Agent Code', 'give-iats' ),
 				'id'   => 'iats_live_agent_code',
 				'type' => 'text',

--- a/includes/admin/class-give-iats-gateways-settings.php
+++ b/includes/admin/class-give-iats-gateways-settings.php
@@ -71,7 +71,7 @@ class Give_iATS_Gateway_Settings {
 	public function add_gateways( $gateways ) {
 		$gateways[ $this->section_id ] = array(
 			'admin_label'    => $this->section_label,
-			'checkout_label' => __( 'Credit Card', 'give-iats' ),
+			'checkout_label' => give_iats_get_payment_method_label(),
 		);
 
 		return $gateways;

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Upgrade Functions
+ *
+ * @package    Give-iATS
+ * @subpackage Admin/Upgrades
+ * @copyright  Copyright (c) 2019, GiveWP
+ * @license    https://opensource.org/licenses/gpl-license GNU Public License
+ * @since      1.0.5
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Perform automatic database upgrades when necessary.
+ *
+ * @since  1.0.5
+ * 
+ * @return void
+ */
+function give_iats_do_automatic_upgrades() {
+	
+	$did_upgrade       = false;
+	$give_iats_version = preg_replace( '/[^0-9.].*/', '', Give_Cache_Setting::get_option( 'give_iats_version' ) );
+
+	if ( ! $give_iats_version ) {
+		// 1.0 is the first version to use this option so we must add it.
+		$give_iats_version = '1.0';
+	}
+
+	switch ( true ) {
+
+		case version_compare( $give_iats_version, '1.0.5', '<' ):
+			give_iats_v105_upgrades();
+			$did_upgrade = true;
+			break;
+	}
+
+	if ( $did_upgrade || version_compare( $give_iats_version, GIVE_IATS_VERSION, '<' ) ) {
+		update_option( 'give_iats_version', preg_replace( '/[^0-9.].*/', '', GIVE_IATS_VERSION ), false );
+	}
+}
+
+add_action( 'admin_init', 'give_iats_do_automatic_upgrades', 0 );
+add_action( 'give_upgrades', 'give_iats_do_automatic_upgrades', 0 );
+
+/**
+ * Upgrade routine for 1.0.5
+ * 
+ * @since 1.0.5
+ *
+ * @return void
+ */
+function give_iats_v105_upgrades() {
+
+	$legacy_gateway_label = give_get_option( 'iats_payment_method_label', __( 'Credit Card', 'give-iats' ) );
+	$gateways_label       = give_get_option( 'gateways_label', array() );
+
+	// Set the legacy payment method label in the new meta key.
+	$gateways_label['iats'] = $legacy_gateway_label;
+
+	// Update the new meta key which handle the payment method labels.
+	give_update_option( 'gateways_label', $gateways_label );
+}

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -63,5 +63,10 @@ function give_iats_v105_upgrades() {
 	$gateways_label['iats'] = $legacy_gateway_label;
 
 	// Update the new meta key which handle the payment method labels.
-	give_update_option( 'gateways_label', $gateways_label );
+	$is_updated = give_update_option( 'gateways_label', $gateways_label );
+
+	// Delete legacy option, if upgrade run successfully.
+	if ( $is_updated ) {
+		give_delete_option( 'iats_payment_method_label' );
+	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -74,7 +74,7 @@ function give_iats_get_server_name() {
 function give_iats_get_payment_method_label() {
 	$give_settings = give_get_settings();
 
-	return ( empty( $give_settings['iats_payment_method_label'] ) ? __( 'Credit Card', 'give-iats' ) : $give_settings['iats_payment_method_label'] );
+	return ( empty( $give_settings['gateways_label']['iats'] ) ? __( 'Credit Card', 'give-iats' ) : $give_settings['gateways_label']['iats'] );
 }
 
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,7 +10,6 @@ $give_settings = give_get_settings();
 
 // Remove plugin settings.
 unset( $give_settings['iats_sandbox_testing'] );
-unset( $give_settings['iats_payment_method_label'] );
 unset( $give_settings['iats_sandbox_agent_code'] );
 unset( $give_settings['iats_sandbox_agent_password'] );
 unset( $give_settings['iats_live_agent_code'] );


### PR DESCRIPTION
## Description
This PR resolves #18  

## How Has This Been Tested?
I've tested this PR by setting a payment method label using the legacy field and then removing the fields reflect the change in the built-in field and changing the label with the in-built field is used. Check Acceptance Criteria on the issue description for more details.

**Displays legacy payment method label in the built-in field which shows backward compatibility**
![image](https://user-images.githubusercontent.com/1852711/58773578-2f55e080-85db-11e9-9ccc-b9e2f14819cb.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
